### PR TITLE
Only set the reload parameter when not using systemd

### DIFF
--- a/mariadb/server/service.sls
+++ b/mariadb/server/service.sls
@@ -1,11 +1,19 @@
+{%- set init_system = salt['grains.get']('init', 'upstart') %}
 # Deal with MySQL service
 extend:
   mysql-server:
     service.running:
       - name: mysql
       - enable: True
-      - reload: True
       - watch:
         - pkg: mysql-server
       - require:
         - pkg: mysql-server
+
+# There is no reload target when using systemd
+{% if init_system != 'systemd' -%}
+extend:
+  mysql-server:
+    service.running:
+      - reload: True
+{% endif %}

--- a/mariadb/server/service.sls
+++ b/mariadb/server/service.sls
@@ -5,15 +5,8 @@ extend:
     service.running:
       - name: mysql
       - enable: True
+      - reload: {% if init_system != 'systemd' -%} True {% else %} False {% endif %}
       - watch:
         - pkg: mysql-server
       - require:
         - pkg: mysql-server
-
-# There is no reload target when using systemd
-{% if init_system != 'systemd' -%}
-extend:
-  mysql-server:
-    service.running:
-      - reload: True
-{% endif %}


### PR DESCRIPTION
### What has been changed

Ubuntu 16.04 installs maria correctly, but when i run other salt-states (like changing the root password) it fails to reload the service. Turns out the systemd provided in the installation has no reload target.

This PR will only set the `reload` flag to true when using no systemd. Resulting in a upstart and systemd friendly environment. ( i guess :smile: ) 
### How to test
- Confirm that changing your mariadb settings at a highstate will reload the service using when using Ubuntu 14.04
- Confirm that changing your mariadb settings at a highstate will restart the service using when using Ubuntu 16.04
