### PR TITLE
Move Salt integration to standalone/optional state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - BS_ECHO_DEBUG=1
     - SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar --file-root=$PWD"
   matrix:
-    - STATE=mariadb.travis,mariadb
+    - STATE=mariadb
 
 before_install:
   - sudo apt-get update

--- a/mariadb/server/conf.sls
+++ b/mariadb/server/conf.sls
@@ -2,21 +2,6 @@
 {% set os_family = salt['grains.get']('os_family', None) %}
 {%- set server_config = salt['pillar.get']('mariadb:server:config') %}
 
-# Teach Salt to use the debian.cnf file
-{%- if os_family == 'Debian' %}
-salt_mysql_config:
-  file.managed:
-    - name: /etc/salt/minion.d/mysql.conf
-    - contents: "mysql.default_file: '/etc/mysql/debian.cnf'"
-    - require:
-      - pkg: salt-minion
-      - pkg: mysql-server
-    - watch_in:
-      - service: salt-minion
-    - require_in:
-      - service: salt-minion
-{% endif %}
-
 {%- if server_config is defined and server_config is mapping %}
 /etc/mysql/conf.d/customized.cnf:
   file.managed:

--- a/mariadb/server/install.sls
+++ b/mariadb/server/install.sls
@@ -26,9 +26,3 @@ mysql-server:
       - debconf: mysql_debconf
 {%- endif %}
 #      - pkgrepo: mariadb_server_repo
-
-# We need python-mysqldb in order to make users and such
-python-mysqldb:
-  pkg.installed:
-    - watch_in:
-      - service: salt-minion

--- a/mariadb/server/salt.sls
+++ b/mariadb/server/salt.sls
@@ -1,0 +1,17 @@
+# Integration for MariaDB into Salt-minion
+{% set os_family = salt['grains.get']('os_family', None) %}
+
+# Teach Salt to use the debian.cnf file
+{%- if os_family == 'Debian' %}
+salt_mysql_config:
+  file.managed:
+    - name: /etc/salt/minion.d/mysql.conf
+    - contents: "mysql.default_file: '/etc/mysql/debian.cnf'"
+    - require:
+      - pkg: salt-minion
+      - pkg: mysql-server
+    - watch_in:
+      - service: salt-minion
+    - require_in:
+      - service: salt-minion
+{% endif %}

--- a/mariadb/server/salt.sls
+++ b/mariadb/server/salt.sls
@@ -15,3 +15,9 @@ salt_mysql_config:
     - require_in:
       - service: salt-minion
 {% endif %}
+
+# We need python-mysqldb in order to make users and such
+python-mysqldb:
+  pkg.installed:
+    - watch_in:
+      - service: salt-minion

--- a/mariadb/travis.sls
+++ b/mariadb/travis.sls
@@ -1,4 +1,0 @@
-# This state is not meant to be used but is included to satisfy some dependencies that Travis requires
-salt-minion:
-  pkg.installed: []
-  service.running: []


### PR DESCRIPTION
Out of the box, its not possible to use the MariaDB formula standalone as it has a dependency to Salt-minion (pkg + service). This PR splits it and turns it into a separate package.
