### PR TITLE
Set the correct os when installing mariadb on debian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+matrix:
+  include:
+    - os: linux
+      dist: precise
+    - os: linux
+      dist: trusty
+
 language: python
 python:
 - '2.7'

--- a/mariadb/repo.sls
+++ b/mariadb/repo.sls
@@ -1,4 +1,4 @@
-{%- set os_family = salt['grains.get']('os_family')|lower %}
+{%- set os_name = salt['grains.get']('os')|lower %}
 {%- set lsb_codename = salt['grains.get']('lsb_distrib_codename') %}
 {%- set stable_version = '10.1' %}
 {%- set repo_version = salt['pillar.get']('mariadb:repo_version', stable_version) %}
@@ -10,9 +10,9 @@
 {% else %}{% set id_prefix = "mariadb" -%}
 {% endif -%}
 
-# Starting with Ubuntu 15.10 the signing key has changed
+# Starting with Ubuntu 16.04 the signing key has changed
 {%- set repo_key = salt['pillar.get']('mariadb:repokey', "0xcbcb082a1bb943db") %}
-{%- if salt['grains.get']('osfullname') == 'Ubuntu' and salt['grains.get']('osrelease')|float() >= 15.10 %}
+{%- if salt['grains.get']('osfullname') == 'Ubuntu' and salt['grains.get']('osrelease')|float() >= 16.04 %}
 {%- set repo_key = "0xF1656F24C74CD1D8" %}
 {%- endif %}
 
@@ -21,11 +21,11 @@
   pkgrepo.managed:
     - humanname: MariaDB PPA
     {%- if version == 'latest' %}
-    - name: deb {{ repourl }}/repo/{{ stable_version }}/{{ os_family }} {{ lsb_codename }} main
+    - name: deb {{ repourl }}/repo/{{ stable_version }}/{{ os_name }} {{ lsb_codename }} main
     {%- elif repo_version %}
-    - name: deb {{ repourl }}/repo/{{ repo_version }}/{{ os_family }} {{ lsb_codename }} main
+    - name: deb {{ repourl }}/repo/{{ repo_version }}/{{ os_name }} {{ lsb_codename }} main
     {%- else %}
-    - name: deb {{ repourl }}/mariadb-{{ version }}/repo/{{ os_family }} {{ lsb_codename }} main
+    - name: deb {{ repourl }}/mariadb-{{ version }}/repo/{{ os_name }} {{ lsb_codename }} main
     {%- endif %}
     - dist: {{ lsb_codename }}
     - file: /etc/apt/sources.list.d/mariadb.list

--- a/mariadb/repo.sls
+++ b/mariadb/repo.sls
@@ -1,4 +1,4 @@
-{%- set os_family = salt['grains.get']('os_family').lower() %}
+{%- set os_family = salt['grains.get']('os_family')|lower %}
 {%- set lsb_codename = salt['grains.get']('lsb_distrib_codename') %}
 {%- set stable_version = '10.1' %}
 {%- set repo_version = salt['pillar.get']('mariadb:repo_version', stable_version) %}

--- a/mariadb/repo.sls
+++ b/mariadb/repo.sls
@@ -1,3 +1,4 @@
+{%- set os_family = salt['grains.get']('os_family').lower() %}
 {%- set lsb_codename = salt['grains.get']('lsb_distrib_codename') %}
 {%- set stable_version = '10.1' %}
 {%- set repo_version = salt['pillar.get']('mariadb:repo_version', stable_version) %}
@@ -20,11 +21,11 @@
   pkgrepo.managed:
     - humanname: MariaDB PPA
     {%- if version == 'latest' %}
-    - name: deb {{ repourl }}/repo/{{ stable_version }}/ubuntu {{ lsb_codename }} main
+    - name: deb {{ repourl }}/repo/{{ stable_version }}/{{ os_family }} {{ lsb_codename }} main
     {%- elif repo_version %}
-    - name: deb {{ repourl }}/repo/{{ repo_version }}/ubuntu {{ lsb_codename }} main
+    - name: deb {{ repourl }}/repo/{{ repo_version }}/{{ os_family }} {{ lsb_codename }} main
     {%- else %}
-    - name: deb {{ repourl }}/mariadb-{{ version }}/repo/ubuntu {{ lsb_codename }} main
+    - name: deb {{ repourl }}/mariadb-{{ version }}/repo/{{ os_family }} {{ lsb_codename }} main
     {%- endif %}
     - dist: {{ lsb_codename }}
     - file: /etc/apt/sources.list.d/mariadb.list


### PR DESCRIPTION
### Ticket
Link to ticket: **No linked ticket**

### What has been done
- Made the configuration of the pkgrepo url more flexible by replacing `ubuntu` with the os_family name from your local salt grains. Allowing me to install mariadb on a Debian 8 machine without extending any states.

### How to test
Using the default configuration and only one inclusion to this formula, you should be able to:
- Install mariadb on a Ubuntu 14.04 machine 
- Install mariadb on a Ubuntu 16.04 machine 
- Install mariadb on a Debian 8 machine